### PR TITLE
ci: Publish the docker image upon main pushes

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,27 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Build Docker image and push to container repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: freifunkh/fnorden-membership-signup:latest


### PR DESCRIPTION
> to https://hub.docker.com/r/freifunkh/fnorden-membership-signup

~This does currently not work due to a lack of credentials.~

this resolves #8 