### PR TITLE
chore: Omit obsolete version in compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     build: .


### PR DESCRIPTION
> Originally, the version property was used to specify the schema version of the Compose file. This was helpful for backward compatibility. However, Docker Compose has evolved, and it now uses the latest Compose Specification by default. This means that specifying a version is redundant and can even lead to warnings.


closes #10 