### PR TITLE
fix: Use the correct G-ID of FNorden

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -175,7 +175,7 @@
                         Betrags verlangen. Es gelten dabei die mit meinem Kreditinstitut vereinbarten Bedingungen.
                     </div>
                     <div class="alert alert-light" role="alert">
-                        Gläubiger-Identifikationsnummer des FNorden e.V.: DE-FIXME-Aiyion.
+                        Gläubiger-Identifikationsnummer des FNorden e.V.: DE05FFH00002771751.
                     </div>
 
                     <h3 style="padding-top:30px">Datenschutz</h3>


### PR DESCRIPTION
> acquired on 11.01.2025 from Deutsche Bundesbank.
> 
> The original documents has been placed in ffh-share and might be used for validation.



This closes #13